### PR TITLE
Fix site references

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -33,7 +33,7 @@
 	      <a href="/">JDBI</a>
         <span id="navigation">
           <a href="/archive.html">Docs</a> |
-          <a href="http://github.com/brianm/jdbi/">Source</a> |
+          <a href="http://github.com/jdbi/jdbi/">Source</a> |
           <a href="/getting_jdbi/">Download</a> |
           <a href="/apidocs">Javadoc</a> |
           <a href="/faq">FAQ</a> |

--- a/_posts/0900-1-1-getting_jdbi.md
+++ b/_posts/0900-1-1-getting_jdbi.md
@@ -22,7 +22,7 @@ You can find the most recent version of JDBI in [Maven Central](http://search.ma
 The JDBI release jar files are available from [Maven Central](http://search.maven.org/#browse%7C1912065227).
 
 # Source Code
-The primary repository for JDBI is on Github at [http://github.com/brianm/jdbi/](http://github.com/brianm/jdbi)
+The primary repository for JDBI is on Github at [http://github.com/jdbi/jdbi/](http://github.com/jdbi/jdbi)
 
 # Mailing List
 JDBI's mailing list is hosted as a Google Group at [https://groups.google.com/group/jdbi](https://groups.google.com/group/jdbi)

--- a/community.html
+++ b/community.html
@@ -13,7 +13,7 @@ title: Convenient SQL for Java
   </p>
   <h2>Issues</h2>
   <p>
-    <a href="https://github.com/brianm/jdbi/issues?state=open">File on Github</a>.
+    <a href="https://github.com/jdbi/jdbi/issues?state=open">File on Github</a>.
   </p>
   <div id="pagination">
     <a href="/">Home</a> | <a href="/archive.html">Docs</a>


### PR DESCRIPTION
Updates links in docs to reflect that JDBI lives under the github.com/jdbi org