### PR TITLE
fix(screen.css): code cut off on mobile devices

### DIFF
--- a/css/screen.css
+++ b/css/screen.css
@@ -216,13 +216,10 @@ pre {
 	background: white;
 	border: 1px solid #ddc;
 	padding: 0.5em 1em;
-	overflow: hidden;
+	overflow-x: auto;
+	overflow-y: hidden;
 }
 
-pre:hover {
-	border-right: none;
-	overflow: visible;
-}
 code {
 	font-size: 1em;
 	background-color: #f7f7ff;


### PR DESCRIPTION
The existing approach relies on the `:hover` pseudo-class to make the code horizontally scrollable on small screens. But this doesn't work on mobile devices since you can't "hover" on a phone/tablet. Instead, the x-axis for code containers should reveal a scrollbar when appropriate. My PR fixes this by making the actual code example scrollable when the code overflows the container.